### PR TITLE
Drop iOS8 support to get rid of SPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "Umbrella",
   platforms: [
-    .macOS(.v10_11), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+    .macOS(.v10_11), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
   ],
   products: [
     .library(name: "Umbrella", targets: ["Umbrella"]),


### PR DESCRIPTION
"The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.5.99."